### PR TITLE
Fixed dark mode background

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -4,8 +4,6 @@
   margin: 0;
   padding: calc(unit * 2);
 
-  background: #fff;
-
   font-size: font-size;
 }
 


### PR DESCRIPTION
Removed the background property in app.css that forced the background color to white. Without it the default color will be used making it white for light mode and dark gray for dark mode.